### PR TITLE
Type hints added to argument 'path' to accept PathLike object

### DIFF
--- a/scrapy/utils/ftp.py
+++ b/scrapy/utils/ftp.py
@@ -1,10 +1,11 @@
 import posixpath
 from ftplib import FTP, error_perm
 from posixpath import dirname
-from typing import IO
+from typing import IO, Union
+from os import PathLike
 
 
-def ftp_makedirs_cwd(ftp: FTP, path: str, first_call: bool = True) -> None:
+def ftp_makedirs_cwd(ftp: FTP, path: Union[str, PathLike[str]], first_call: bool = True) -> None:
     """Set the current directory of the FTP connection given in the ``ftp``
     argument (as a ftplib.FTP object), creating all parent directories if they
     don't exist. The ftplib.FTP object must be already connected and logged in.
@@ -20,7 +21,7 @@ def ftp_makedirs_cwd(ftp: FTP, path: str, first_call: bool = True) -> None:
 
 def ftp_store_file(
     *,
-    path: str,
+    path: Union[str, PathLike[str]],
     file: IO,
     host: str,
     port: int,


### PR DESCRIPTION
Fixes #4 

PathLike object was added to 'path' argument in the ftp.py file